### PR TITLE
Clear code display on vault close

### DIFF
--- a/frontend/src/lib/components/EntryList.svelte
+++ b/frontend/src/lib/components/EntryList.svelte
@@ -1,18 +1,16 @@
 <script>
     import EntryItem from './EntryItem.svelte';
-    import { search } from '$lib/stores';
+    import { items, search } from '$lib/stores';
     import { closeFile } from '$lib/util';
     import { EventsOn } from '$wails/runtime/runtime';
 
-    let items = [];
-
-    $: filteredItems = items.filter(item => {
+    $: filteredItems = $items.filter(item => {
         const searchRE = new RegExp($search, 'i');
         const { issuer, name } = item.entry;
         return searchRE.test(issuer) || searchRE.test(name);
     });
 
-    EventsOn('onCodesUpdated', (entryCodes) => items = entryCodes);
+    EventsOn('onCodesUpdated', (entryCodes) => $items = entryCodes);
 </script>
 
 {#if filteredItems.length === 0}

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -26,7 +26,7 @@ function openExtUrl(event) {
         </ul>
 
         <ul>
-            <li><small>v1.2.0</small></li>
+            <li><small>v1.3.0-dev</small></li>
         </ul>
     </nav>
 </footer>

--- a/frontend/src/lib/stores.js
+++ b/frontend/src/lib/stores.js
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
 
 export const vaultPath = writable();
+export const items = writable([]);
 export const search = writable('');

--- a/frontend/src/lib/util.js
+++ b/frontend/src/lib/util.js
@@ -1,4 +1,4 @@
-import { vaultPath, search } from './stores';
+import { vaultPath, search, items } from './stores';
 import { CloseVault } from '$wails/go/main/App';
 
 /**
@@ -26,12 +26,13 @@ export function formatCode(code) {
 }
 
 /**
- * Closes the current vault and clears the vault path store. 
+ * Closes the current vault and clears the frontend's vault data. 
  * This triggers the selection modal to display.
  */
 export async function closeFile() {
     await CloseVault();
 
     vaultPath.set(null);
+    items.set([]);
     search.set('');
 }


### PR DESCRIPTION
The last displayed OTP codes of the closed vault remained behind the blurred background of the selection modal but it's still better to just remove those previous codes.