### PR TITLE
Disable targeting 'dev' for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,10 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
-    target-branch: "dev"
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
-    target-branch: "dev"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
It shouldn't be necessary to target the 'dev' branch for dependency updates.