### PR TITLE
Remove backdrop-filter

### DIFF
--- a/frontend/src/lib/components/GroupFilter.svelte
+++ b/frontend/src/lib/components/GroupFilter.svelte
@@ -23,8 +23,7 @@
     .group-filter {
         padding: calc(var(--pico-spacing) * 0.5) calc(var(--pico-spacing) * 1.5);
         border-bottom: 1px solid #ffffffb0;
-        background-color: #a3b2cc61;
-        backdrop-filter: blur(4px);
+        background-color: #b5c6e2;
         padding-bottom: calc(var(--pico-spacing) * 0.75);
         position: sticky;
         top: 0;


### PR DESCRIPTION
Apparently `backdrop-filter` is yet another issue with webkit on Linux. It fails to render even when `-webkit-` prefixed.

I thought the aesthetic of the filter was much nicer for the platforms that support it but a solid, opaque background will just have to do.

Addresses #87.